### PR TITLE
Enable dynamic loading of later versions of distributed vulkan libraries on windows

### DIFF
--- a/Src/Khx/InstanceExtensions.cs
+++ b/Src/Khx/InstanceExtensions.cs
@@ -17,7 +17,12 @@ namespace VulkanCore.Khx
         public static PhysicalDeviceGroupPropertiesKhx[] EnumeratePhysicalDeviceGroupsKhx(this Instance instance)
         {
             int count;
-            Result result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, null);
+			if (vkEnumeratePhysicalDeviceGroupsKHX == null)
+			{
+		        throw new MissingMethodException(nameof(vkEnumeratePhysicalDeviceGroupsKHX));
+	        }
+
+			Result result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, null);
             VulkanException.ThrowForInvalidResult(result);
 
             var nativeProperties = stackalloc PhysicalDeviceGroupPropertiesKhx.Native[count];

--- a/Src/VulkanCore.csproj
+++ b/Src/VulkanCore.csproj
@@ -20,6 +20,7 @@
     <DocumentationFile>bin\Debug\netstandard1.3\VulkanCore.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
enable dynamic loading of later versions of distributed vulkan libraries on windows

explicitly report MissingMethodException when vkEnumeratePhysicalDeviceGroupsKHX is not found

added SearchExecutablePath as platform agnostic method of searching "%PATH%" or "$PATH"
(though here, explicitly for use on windows)