### PR TITLE
WIP: vkEnumeratePhysicalDeviceGroupsKHX support

### DIFF
--- a/Src/Interop.cs
+++ b/Src/Interop.cs
@@ -163,7 +163,7 @@ namespace VulkanCore
         /// </summary>
         /// <typeparam name="T">The type of object whose size is retrieved.</typeparam>
         /// <returns>The size of an object of type <typeparamref name="T"/>.</returns>
-        public static int SizeOf<T>() => Unsafe.SizeOf<T>();
+        public static int SizeOf<T>() => Marshal.SizeOf<T>();
 
         /// <summary>
         /// Casts the gived object to the specified type.

--- a/Src/Khx/DeviceExtensions.cs
+++ b/Src/Khx/DeviceExtensions.cs
@@ -768,6 +768,26 @@ namespace VulkanCore.Khx
             PhysicalDeviceCount = physicalDevices?.Length ?? 0;
             PhysicalDevices = physicalDevices?.ToHandleArray();
         }
+		
+	    [StructLayout(LayoutKind.Sequential)]
+	    internal struct Native
+	    {
+		    public StructureType Type;
+		    public IntPtr Next;
+		    public int PhysicalDeviceCount;
+		    public IntPtr PhysicalDevices;
+	    }
+
+	    public unsafe IntPtr ToNative()
+	    {
+			Native* pNative = (Native*)Interop.Alloc<Native>(1);
+		    pNative->Type = Type;
+		    pNative->Next = Next;
+		    pNative->PhysicalDeviceCount = PhysicalDeviceCount;
+		    pNative->PhysicalDevices = Interop.Struct.AllocToPointer(PhysicalDevices);
+		    return (IntPtr) pNative;
+	    }
+
     }
 
     /// <summary>

--- a/Src/Khx/InstanceExtensions.cs
+++ b/Src/Khx/InstanceExtensions.cs
@@ -24,28 +24,32 @@ namespace VulkanCore.Khx
 			        .GetProc<vkEnumeratePhysicalDeviceGroupsKHXDelegate>
 						(nameof(vkEnumeratePhysicalDeviceGroupsKHX));
 	        }
-
-	        Result result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, null);
+			
+	        Result result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, default(IntPtr));
             VulkanException.ThrowForInvalidResult(result);
 
-            var nativeProperties = stackalloc PhysicalDeviceGroupPropertiesKhx.Native[count];
-            result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, nativeProperties);
+	        var structSize = Marshal.SizeOf<PhysicalDeviceGroupPropertiesKhx.Native>();
+	        var allocSize = structSize * count;
+	        var nativePropertiesPtr = stackalloc byte[allocSize];
+            result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, (IntPtr)nativePropertiesPtr);
             VulkanException.ThrowForInvalidResult(result);
 
             var groupProperties = new PhysicalDeviceGroupPropertiesKhx[count];
             for (int i = 0; i < count; i++)
             {
-                ref PhysicalDeviceGroupPropertiesKhx.Native nativeProps = ref nativeProperties[i];
-                var devices = new PhysicalDevice[nativeProps.PhysicalDeviceCount];
-                for (int j = 0; j < nativeProps.PhysicalDeviceCount; j++)
-                    devices[j] = new PhysicalDevice(nativeProps.PhysicalDevices[j], instance);
-                PhysicalDeviceGroupPropertiesKhx.FromNative(ref nativeProps, devices, out groupProperties[i]);
+	            var nativeProperty = Marshal.PtrToStructure<PhysicalDeviceGroupPropertiesKhx.Native>
+					((IntPtr)nativePropertiesPtr + structSize*i);
+                var devices = new PhysicalDevice[nativeProperty.PhysicalDeviceCount];
+                for (int j = 0; j < nativeProperty.PhysicalDeviceCount; j++)
+                    devices[j] = new PhysicalDevice(nativeProperty.PhysicalDevices[j], instance);
+                PhysicalDeviceGroupPropertiesKhx.FromNative(ref nativeProperty, devices, out groupProperties[i]);
             }
+			
 
             return groupProperties;
         }
 
-        private delegate Result vkEnumeratePhysicalDeviceGroupsKHXDelegate(IntPtr instance, int* physicalDeviceGroupCount, PhysicalDeviceGroupPropertiesKhx.Native* physicalDeviceGroupProperties);
+        private delegate Result vkEnumeratePhysicalDeviceGroupsKHXDelegate(IntPtr instance, int* physicalDeviceGroupCount, IntPtr physicalDeviceGroupProperties);
         private static vkEnumeratePhysicalDeviceGroupsKHXDelegate vkEnumeratePhysicalDeviceGroupsKHX = VulkanLibrary.GetProc<vkEnumeratePhysicalDeviceGroupsKHXDelegate>(nameof(vkEnumeratePhysicalDeviceGroupsKHX));
     }
 
@@ -70,15 +74,15 @@ namespace VulkanCore.Khx
         /// physicalDeviceCount is 1, then <see cref="SubsetAllocation"/> must be <c>false</c>.
         /// </summary>
         public Bool SubsetAllocation;
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct Native
+		
+	    [StructLayout(LayoutKind.Sequential)]
+	    internal struct Native
         {
             public StructureType Type;
             public IntPtr Next;
             public int PhysicalDeviceCount;
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public IntPtr* PhysicalDevices; // TODO: validate
+            public IntPtr[] PhysicalDevices;
             public Bool SubsetAllocation;
         }
 

--- a/Src/Khx/InstanceExtensions.cs
+++ b/Src/Khx/InstanceExtensions.cs
@@ -81,7 +81,7 @@ namespace VulkanCore.Khx
             public StructureType Type;
             public IntPtr Next;
             public int PhysicalDeviceCount;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constant.MaxDeviceGroupSizeKhx)]
             public IntPtr[] PhysicalDevices;
             public Bool SubsetAllocation;
         }

--- a/Src/Khx/InstanceExtensions.cs
+++ b/Src/Khx/InstanceExtensions.cs
@@ -28,9 +28,8 @@ namespace VulkanCore.Khx
 	        Result result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, default(IntPtr));
             VulkanException.ThrowForInvalidResult(result);
 
-	        var structSize = Marshal.SizeOf<PhysicalDeviceGroupPropertiesKhx.Native>();
-	        var allocSize = structSize * count;
-	        var nativePropertiesPtr = stackalloc byte[allocSize];
+	        var structSize = Interop.SizeOf<PhysicalDeviceGroupPropertiesKhx.Native>();
+	        var nativePropertiesPtr = stackalloc byte[structSize * count];
             result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, (IntPtr)nativePropertiesPtr);
             VulkanException.ThrowForInvalidResult(result);
 

--- a/Src/Khx/InstanceExtensions.cs
+++ b/Src/Khx/InstanceExtensions.cs
@@ -17,7 +17,15 @@ namespace VulkanCore.Khx
         public static PhysicalDeviceGroupPropertiesKhx[] EnumeratePhysicalDeviceGroupsKhx(this Instance instance)
         {
             int count;
-            Result result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, null);
+
+	        if (vkEnumeratePhysicalDeviceGroupsKHX == null)
+			{
+		        vkEnumeratePhysicalDeviceGroupsKHX = instance
+			        .GetProc<vkEnumeratePhysicalDeviceGroupsKHXDelegate>
+						(nameof(vkEnumeratePhysicalDeviceGroupsKHX));
+	        }
+
+	        Result result = vkEnumeratePhysicalDeviceGroupsKHX(instance, &count, null);
             VulkanException.ThrowForInvalidResult(result);
 
             var nativeProperties = stackalloc PhysicalDeviceGroupPropertiesKhx.Native[count];
@@ -38,7 +46,7 @@ namespace VulkanCore.Khx
         }
 
         private delegate Result vkEnumeratePhysicalDeviceGroupsKHXDelegate(IntPtr instance, int* physicalDeviceGroupCount, PhysicalDeviceGroupPropertiesKhx.Native* physicalDeviceGroupProperties);
-        private static readonly vkEnumeratePhysicalDeviceGroupsKHXDelegate vkEnumeratePhysicalDeviceGroupsKHX = VulkanLibrary.GetProc<vkEnumeratePhysicalDeviceGroupsKHXDelegate>(nameof(vkEnumeratePhysicalDeviceGroupsKHX));
+        private static vkEnumeratePhysicalDeviceGroupsKHXDelegate vkEnumeratePhysicalDeviceGroupsKHX = VulkanLibrary.GetProc<vkEnumeratePhysicalDeviceGroupsKHXDelegate>(nameof(vkEnumeratePhysicalDeviceGroupsKHX));
     }
 
     /// <summary>


### PR DESCRIPTION
Load vkEnumeratePhysicalDeviceGroupsKHX from static export, but fall back to using instance.GetProc (vkGetInstanceProcAddr)

See #8 