### PR TITLE
Fixed sample synchronization

### DIFF
--- a/Samples/MiniFramework/VulkanApp.cs
+++ b/Samples/MiniFramework/VulkanApp.cs
@@ -81,7 +81,6 @@ namespace VulkanCore.Samples
                 ToDispose(SubmitFences[i] = Context.Device.CreateFence(new FenceCreateInfo(FenceCreateFlags.Signaled))); 
 
             // Allow concrete samples to initialize their resources.
-            _initializingPermanent = true;
             InitializePermanent();
             _initializingPermanent = false;
             InitializeFrame();

--- a/Samples/Shared/01-ClearScreen/ClearScreenApp.cs
+++ b/Samples/Shared/01-ClearScreen/ClearScreenApp.cs
@@ -35,12 +35,17 @@ namespace VulkanCore.Samples.ClearScreen
             // Acquire an index of drawing image for this frame.
             int imageIndex = Swapchain.AcquireNextImage(semaphore: ImageAvailableSemaphore);
 
+            // Use a fence to wait until the command buffer has finished execution before using it again
+            SubmitFences[imageIndex].Wait();
+            SubmitFences[imageIndex].Reset();
+
             // Submit recorded commands to graphics queue for execution.
             Context.GraphicsQueue.Submit(
                 ImageAvailableSemaphore,
                 PipelineStages.Transfer,
                 CommandBuffers[imageIndex],
-                RenderingFinishedSemaphore
+                RenderingFinishedSemaphore,
+                SubmitFences[imageIndex]
             );
 
             // Present the color output to screen.

--- a/Samples/Shared/MacOSWindow.cs
+++ b/Samples/Shared/MacOSWindow.cs
@@ -78,10 +78,6 @@ namespace VulkanCore.Samples
                 _timer.Tick();
                 if (!_appPaused)
                 {
-                    float elapsedMiliseconds = _timer.DeltaTime * 1000f;
-                    if(elapsedMiliseconds < 16)
-                        Thread.Sleep(16 - (int)elapsedMiliseconds);
-
                     CalculateFrameRateStats();
                     _app.Tick(_timer);
                 }


### PR DESCRIPTION
I was debugging why the samples 01, 02, and 03 where hanging on either close or resize when the cpu tick-rate was too high on moltenVK. Basically the 'Context.Device.WaitIdle();' would seemingly never return. After digging it seemed that the gpu was capping at 60hz (present mode FiFo) but the cpu loop would run at 1000+hz, and would keep queuing up commands in the graphicsQueue. Issue is also discussed here: https://github.com/KhronosGroup/MoltenVK/issues/95. To fix this i've added syncing using fences according to a SaschaWillems sample (https://github.com/SaschaWillems/Vulkan/blob/master/examples/triangle/triangle.cpp)

