### PR TITLE
Fix for issue #21

### DIFF
--- a/Samples/Shared/Win32Window.cs
+++ b/Samples/Shared/Win32Window.cs
@@ -63,7 +63,7 @@ namespace VulkanCore.Samples
             };
             _form.Activated += (sender, e) =>
             {
-                _appPaused = false;
+                _appPaused = _form.WindowState != FormWindowState.Normal;
                 _timer.Start();
             };
             _form.Deactivate += (sender, e) =>


### PR DESCRIPTION
When returning from a minimised state on windows it would throw a: 'OutOfDateKHR' on the 'vkQueuePresentKHR' because of ordering of events in Win32Window.cs

Received event order on minimize and restore:
1 _form.Resize with _form.WindowState == Minimized
2 _form.Deactivated
3 _form.Activated

So the .Resize callback would properly set _appPaused but the .Activate would unset it again causing the 'Run' to render even though the surface was out of date.