### PR TITLE
Removed explicit dependencies from the MacOS projects

### DIFF
--- a/Samples/MacOS/01-ClearScreen/01-ClearScreen.csproj
+++ b/Samples/MacOS/01-ClearScreen/01-ClearScreen.csproj
@@ -27,10 +27,6 @@
       <Name>MiniFramework</Name>
     </ProjectReference>
   
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.4.0</Version>
-    </PackageReference>
-  
     <Reference Include="NativeMacOS">
       <HintPath>../../Shared/NativeMacOS/NativeMacOS.dll</HintPath> 
     </Reference>

--- a/Samples/MacOS/02-ColoredTriangle/02-ColoredTriangle.csproj
+++ b/Samples/MacOS/02-ColoredTriangle/02-ColoredTriangle.csproj
@@ -45,14 +45,6 @@
       <Name>MiniFramework</Name>
     </ProjectReference>
   
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.4.0</Version>
-    </PackageReference>
-  
-    <PackageReference Include="System.Numerics.Vectors">
-      <Version>4.4.0</Version>
-    </PackageReference>
-  
     <Reference Include="NativeMacOS">
       <HintPath>../../Shared/NativeMacOS/NativeMacOS.dll</HintPath> 
     </Reference>

--- a/Samples/MacOS/03-TexturedCube/03-TexturedCube.csproj
+++ b/Samples/MacOS/03-TexturedCube/03-TexturedCube.csproj
@@ -46,14 +46,6 @@
       <Name>MiniFramework</Name>
     </ProjectReference>
   
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.4.0</Version>
-    </PackageReference>
-  
-    <PackageReference Include="System.Numerics.Vectors">
-      <Version>4.4.0</Version>
-    </PackageReference>
-  
     <Reference Include="NativeMacOS">
       <HintPath>../../Shared/NativeMacOS/NativeMacOS.dll</HintPath> 
     </Reference>

--- a/Samples/MacOS/04-ComputeParticles/04-ComputeParticles.csproj
+++ b/Samples/MacOS/04-ComputeParticles/04-ComputeParticles.csproj
@@ -56,14 +56,6 @@
       <Name>MiniFramework</Name>
     </ProjectReference>
   
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.4.0</Version>
-    </PackageReference>
-  
-    <PackageReference Include="System.Numerics.Vectors">
-      <Version>4.4.0</Version>
-    </PackageReference>
-  
     <Reference Include="NativeMacOS">
       <HintPath>../../Shared/NativeMacOS/NativeMacOS.dll</HintPath> 
     </Reference>


### PR DESCRIPTION
Those dependencies turned out to be unnecessary because they are already pulled in by 'MiniFramework' and at the moment they did not match the dependencies listed there.